### PR TITLE
Implement two-deck Dioxus UI with crossfader

### DIFF
--- a/crates/rustymixer-library/Cargo.toml
+++ b/crates/rustymixer-library/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 rustymixer-core = { workspace = true }
 rusqlite = { workspace = true }
 lofty = { workspace = true }
+crossbeam = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rustymixer-library/src/dao/crate_dao.rs
+++ b/crates/rustymixer-library/src/dao/crate_dao.rs
@@ -5,9 +5,8 @@
 use rusqlite::{Connection, params};
 
 use crate::error::Result;
-use crate::models;
+use crate::models::{self, CrateSummary, Track};
 use super::track::TrackDao;
-use crate::models::Track;
 
 pub struct CrateDao;
 
@@ -19,6 +18,21 @@ impl CrateDao {
             params![name, now],
         )?;
         Ok(conn.last_insert_rowid())
+    }
+
+    pub fn get_by_id(conn: &Connection, id: i64) -> Result<Option<models::Crate>> {
+        let mut stmt = conn.prepare(
+            "SELECT id, name, created_at FROM crates WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query([id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(models::Crate {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                created_at: row.get(2)?,
+            })),
+            None => Ok(None),
+        }
     }
 
     pub fn rename(conn: &Connection, id: i64, name: &str) -> Result<()> {
@@ -42,6 +56,26 @@ impl CrateDao {
                 id: row.get(0)?,
                 name: row.get(1)?,
                 created_at: row.get(2)?,
+            })
+        })?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    /// List all crates with their track counts.
+    pub fn list_with_counts(conn: &Connection) -> Result<Vec<CrateSummary>> {
+        let mut stmt = conn.prepare(
+            "SELECT c.id, c.name, c.created_at, COUNT(ct.track_id) AS track_count
+             FROM crates c
+             LEFT JOIN crate_tracks ct ON c.id = ct.crate_id
+             GROUP BY c.id
+             ORDER BY c.name",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(CrateSummary {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                created_at: row.get(2)?,
+                track_count: row.get::<_, i64>(3)? as usize,
             })
         })?;
         Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)

--- a/crates/rustymixer-library/src/dao/location.rs
+++ b/crates/rustymixer-library/src/dao/location.rs
@@ -41,6 +41,31 @@ impl LocationDao {
         }
     }
 
+    pub fn update(conn: &Connection, loc: &TrackLocation) -> Result<()> {
+        conn.execute(
+            "UPDATE track_locations SET directory_id = ?1, filename = ?2, filesize = ?3,
+             fs_modified_at = ?4, needs_verification = ?5 WHERE id = ?6",
+            params![
+                loc.directory_id,
+                loc.filename,
+                loc.filesize,
+                loc.fs_modified_at,
+                loc.needs_verification as i32,
+                loc.id,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_by_directory(conn: &Connection, dir_id: i64) -> Result<Vec<TrackLocation>> {
+        let mut stmt = conn.prepare(
+            "SELECT id, directory_id, filename, filesize, fs_modified_at, needs_verification
+             FROM track_locations WHERE directory_id = ?1",
+        )?;
+        let rows = stmt.query_map([dir_id], row_to_location)?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
     pub fn mark_needs_verification(conn: &Connection, id: i64) -> Result<()> {
         conn.execute(
             "UPDATE track_locations SET needs_verification = 1 WHERE id = ?1",

--- a/crates/rustymixer-library/src/dao/playlist.rs
+++ b/crates/rustymixer-library/src/dao/playlist.rs
@@ -2,10 +2,9 @@
 
 use rusqlite::{Connection, params};
 
-use crate::error::Result;
-use crate::models::Playlist;
+use crate::error::{LibraryError, Result};
+use crate::models::{Playlist, PlaylistSummary, Track};
 use super::track::TrackDao;
-use crate::models::Track;
 
 pub struct PlaylistDao;
 
@@ -22,6 +21,23 @@ impl PlaylistDao {
             params![name, position, now],
         )?;
         Ok(conn.last_insert_rowid())
+    }
+
+    pub fn get_by_id(conn: &Connection, id: i64) -> Result<Option<Playlist>> {
+        let mut stmt = conn.prepare(
+            "SELECT id, name, position, created_at, is_locked FROM playlists WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query([id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(Playlist {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                position: row.get(2)?,
+                created_at: row.get(3)?,
+                is_locked: row.get::<_, i32>(4)? != 0,
+            })),
+            None => Ok(None),
+        }
     }
 
     pub fn rename(conn: &Connection, id: i64, name: &str) -> Result<()> {
@@ -52,6 +68,29 @@ impl PlaylistDao {
         Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
     }
 
+    /// List all playlists with their track counts.
+    pub fn list_with_counts(conn: &Connection) -> Result<Vec<PlaylistSummary>> {
+        let mut stmt = conn.prepare(
+            "SELECT p.id, p.name, p.position, p.created_at, p.is_locked,
+                    COUNT(pt.track_id) AS track_count
+             FROM playlists p
+             LEFT JOIN playlist_tracks pt ON p.id = pt.playlist_id
+             GROUP BY p.id
+             ORDER BY p.position",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(PlaylistSummary {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                position: row.get(2)?,
+                created_at: row.get(3)?,
+                is_locked: row.get::<_, i32>(4)? != 0,
+                track_count: row.get::<_, i64>(5)? as usize,
+            })
+        })?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
     pub fn add_track(conn: &Connection, playlist_id: i64, track_id: i64) -> Result<()> {
         let position: i64 = conn.query_row(
             "SELECT COALESCE(MAX(position), -1) + 1 FROM playlist_tracks WHERE playlist_id = ?1",
@@ -71,6 +110,67 @@ impl PlaylistDao {
             params![playlist_id, track_id],
         )?;
         Ok(())
+    }
+
+    /// Move a track from `from_pos` to `to_pos` within a playlist, shifting
+    /// other entries to maintain contiguous ordering.
+    pub fn move_track(conn: &Connection, playlist_id: i64, from_pos: i32, to_pos: i32) -> Result<()> {
+        if from_pos == to_pos {
+            return Ok(());
+        }
+
+        // Get the track_id at from_pos.
+        let track_id: i64 = conn
+            .query_row(
+                "SELECT track_id FROM playlist_tracks WHERE playlist_id = ?1 AND position = ?2",
+                params![playlist_id, from_pos],
+                |row| row.get(0),
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    LibraryError::NotFound(format!("no track at position {from_pos}"))
+                }
+                other => LibraryError::Database(other),
+            })?;
+
+        if from_pos < to_pos {
+            // Moving down: shift items in (from_pos, to_pos] up by one.
+            conn.execute(
+                "UPDATE playlist_tracks SET position = position - 1
+                 WHERE playlist_id = ?1 AND position > ?2 AND position <= ?3",
+                params![playlist_id, from_pos, to_pos],
+            )?;
+        } else {
+            // Moving up: shift items in [to_pos, from_pos) down by one.
+            conn.execute(
+                "UPDATE playlist_tracks SET position = position + 1
+                 WHERE playlist_id = ?1 AND position >= ?2 AND position < ?3",
+                params![playlist_id, to_pos, from_pos],
+            )?;
+        }
+
+        // Place the moved track at to_pos.
+        conn.execute(
+            "UPDATE playlist_tracks SET position = ?1
+             WHERE playlist_id = ?2 AND track_id = ?3",
+            params![to_pos, playlist_id, track_id],
+        )?;
+
+        Ok(())
+    }
+
+    /// Duplicate a playlist with a new name, copying all track entries.
+    pub fn duplicate(conn: &Connection, id: i64, new_name: &str) -> Result<i64> {
+        let new_id = Self::create(conn, new_name)?;
+
+        conn.execute(
+            "INSERT INTO playlist_tracks (playlist_id, track_id, position)
+             SELECT ?1, track_id, position FROM playlist_tracks WHERE playlist_id = ?2
+             ORDER BY position",
+            params![new_id, id],
+        )?;
+
+        Ok(new_id)
     }
 
     pub fn tracks(conn: &Connection, playlist_id: i64) -> Result<Vec<Track>> {

--- a/crates/rustymixer-library/src/error.rs
+++ b/crates/rustymixer-library/src/error.rs
@@ -19,6 +19,9 @@ pub enum LibraryError {
 
     #[error("metadata error: {0}")]
     Metadata(#[from] lofty::error::LoftyError),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 pub type Result<T> = std::result::Result<T, LibraryError>;

--- a/crates/rustymixer-library/src/import.rs
+++ b/crates/rustymixer-library/src/import.rs
@@ -1,0 +1,134 @@
+//\! Playlist import — M3U and PLS file parsers.
+
+use std::io::BufRead;
+use std::path::Path;
+
+use rusqlite::{Connection, params};
+use tracing::debug;
+
+use crate::error::Result;
+use crate::models::ImportResult;
+use crate::dao::playlist::PlaylistDao;
+
+/// Import an M3U playlist file into the library.
+///
+/// Reads line by line, skips comments (`#`), resolves relative paths against
+/// the M3U file's parent directory, and matches each path to library tracks
+/// via the `track_locations` + `directories` tables.
+pub fn import_m3u(conn: &Connection, path: &Path, playlist_name: &str) -> Result<ImportResult> {
+    let base_dir = path.parent().unwrap_or(Path::new("."));
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+
+    let playlist_id = PlaylistDao::create(conn, playlist_name)?;
+    let mut imported = 0usize;
+    let mut not_found = 0usize;
+
+    for line in reader.lines() {
+        let line = line?;
+        let line = line.trim();
+
+        // Skip empty lines and comments.
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let file_path = if Path::new(line).is_absolute() {
+            std::path::PathBuf::from(line)
+        } else {
+            base_dir.join(line)
+        };
+
+        // Canonicalize to resolve ../ and symlinks, fall back to the
+        // joined path if canonicalize fails (file might not exist).
+        let file_path = file_path.canonicalize().unwrap_or(file_path);
+
+        match find_track_by_path(conn, &file_path)? {
+            Some(track_id) => {
+                PlaylistDao::add_track(conn, playlist_id, track_id)?;
+                imported += 1;
+            }
+            None => {
+                debug!(?file_path, "M3U entry not found in library");
+                not_found += 1;
+            }
+        }
+    }
+
+    Ok(ImportResult { imported, not_found })
+}
+
+/// Import a PLS playlist file into the library.
+///
+/// PLS files use INI-like format with `FileN=path` entries.
+pub fn import_pls(conn: &Connection, path: &Path, playlist_name: &str) -> Result<ImportResult> {
+    let base_dir = path.parent().unwrap_or(Path::new("."));
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+
+    let playlist_id = PlaylistDao::create(conn, playlist_name)?;
+    let mut imported = 0usize;
+    let mut not_found = 0usize;
+
+    for line in reader.lines() {
+        let line = line?;
+        let line = line.trim();
+
+        // PLS entries look like: File1=/path/to/song.mp3
+        let entry = match line.strip_prefix("File") {
+            Some(rest) => {
+                // Skip the number and '='
+                rest.split_once('=').map(|(_, path)| path)
+            }
+            None => None,
+        };
+
+        let Some(entry) = entry else {
+            continue;
+        };
+
+        let file_path = if Path::new(entry).is_absolute() {
+            std::path::PathBuf::from(entry)
+        } else {
+            base_dir.join(entry)
+        };
+
+        let file_path = file_path.canonicalize().unwrap_or(file_path);
+
+        match find_track_by_path(conn, &file_path)? {
+            Some(track_id) => {
+                PlaylistDao::add_track(conn, playlist_id, track_id)?;
+                imported += 1;
+            }
+            None => {
+                debug!(?file_path, "PLS entry not found in library");
+                not_found += 1;
+            }
+        }
+    }
+
+    Ok(ImportResult { imported, not_found })
+}
+
+/// Look up a track by its full file path, joining directories and
+/// track_locations tables.
+fn find_track_by_path(conn: &Connection, path: &Path) -> Result<Option<i64>> {
+    let path_str = path.to_string_lossy();
+
+    // Match against `directories.path || '/' || track_locations.filename`.
+    let result: std::result::Result<i64, _> = conn.query_row(
+        "SELECT t.id
+         FROM tracks t
+         JOIN track_locations tl ON t.location_id = tl.id
+         JOIN directories d ON tl.directory_id = d.id
+         WHERE d.path || '/' || tl.filename = ?1",
+        params![path_str],
+        |row| row.get(0),
+    );
+
+    match result {
+        Ok(id) => Ok(Some(id)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/crates/rustymixer-library/src/lib.rs
+++ b/crates/rustymixer-library/src/lib.rs
@@ -8,11 +8,13 @@ pub mod db;
 pub mod error;
 pub mod metadata;
 pub mod models;
+pub mod scanner;
 pub mod schema;
 
 pub use db::Database;
 pub use error::{LibraryError, Result};
 pub use metadata::{CoverArt, MetadataReader, TrackMetadata};
 pub use models::*;
+pub use scanner::{spawn_scan, LibraryScanner, ScanHandle, ScanPhase, ScanProgress, ScanResult};
 
 pub use dao::{CrateDao, CueDao, DirectoryDao, LocationDao, PlaylistDao, SettingsDao, TrackDao};

--- a/crates/rustymixer-library/src/lib.rs
+++ b/crates/rustymixer-library/src/lib.rs
@@ -6,6 +6,8 @@
 pub mod dao;
 pub mod db;
 pub mod error;
+pub mod import;
+pub mod manager;
 pub mod metadata;
 pub mod models;
 pub mod scanner;
@@ -13,6 +15,7 @@ pub mod schema;
 
 pub use db::Database;
 pub use error::{LibraryError, Result};
+pub use manager::LibraryManager;
 pub use metadata::{CoverArt, MetadataReader, TrackMetadata};
 pub use models::*;
 pub use scanner::{spawn_scan, LibraryScanner, ScanHandle, ScanPhase, ScanProgress, ScanResult};

--- a/crates/rustymixer-library/src/manager.rs
+++ b/crates/rustymixer-library/src/manager.rs
@@ -1,0 +1,120 @@
+//\! High-level library manager that wraps all playlist and crate operations.
+
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use crate::dao::crate_dao::CrateDao;
+use crate::dao::playlist::PlaylistDao;
+use crate::error::Result;
+use crate::import;
+use crate::models::{
+    CrateSummary, ImportResult, Playlist, PlaylistSummary, Track,
+};
+
+/// Unified API for playlist and crate management.
+pub struct LibraryManager {
+    db: Connection,
+}
+
+impl LibraryManager {
+    /// Create a new manager wrapping the given connection.
+    pub fn new(db: Connection) -> Self {
+        Self { db }
+    }
+
+    /// Borrow the underlying connection (for direct DAO access or tests).
+    pub fn conn(&self) -> &Connection {
+        &self.db
+    }
+
+    // -----------------------------------------------------------------
+    // Playlist operations
+    // -----------------------------------------------------------------
+
+    pub fn create_playlist(&self, name: &str) -> Result<Playlist> {
+        let id = PlaylistDao::create(&self.db, name)?;
+        PlaylistDao::get_by_id(&self.db, id)?
+            .ok_or_else(|| crate::error::LibraryError::NotFound("playlist just created".into()))
+    }
+
+    pub fn delete_playlist(&self, id: i64) -> Result<()> {
+        PlaylistDao::delete(&self.db, id)
+    }
+
+    pub fn rename_playlist(&self, id: i64, name: &str) -> Result<()> {
+        PlaylistDao::rename(&self.db, id, name)
+    }
+
+    pub fn playlist_add_track(&self, playlist_id: i64, track_id: i64) -> Result<()> {
+        PlaylistDao::add_track(&self.db, playlist_id, track_id)
+    }
+
+    pub fn playlist_remove_track(&self, playlist_id: i64, track_id: i64) -> Result<()> {
+        PlaylistDao::remove_track(&self.db, playlist_id, track_id)
+    }
+
+    pub fn playlist_move_track(&self, playlist_id: i64, from_pos: i32, to_pos: i32) -> Result<()> {
+        PlaylistDao::move_track(&self.db, playlist_id, from_pos, to_pos)
+    }
+
+    pub fn playlist_tracks(&self, playlist_id: i64) -> Result<Vec<Track>> {
+        PlaylistDao::tracks(&self.db, playlist_id)
+    }
+
+    pub fn list_playlists(&self) -> Result<Vec<PlaylistSummary>> {
+        PlaylistDao::list_with_counts(&self.db)
+    }
+
+    pub fn duplicate_playlist(&self, id: i64, new_name: &str) -> Result<Playlist> {
+        let new_id = PlaylistDao::duplicate(&self.db, id, new_name)?;
+        PlaylistDao::get_by_id(&self.db, new_id)?
+            .ok_or_else(|| crate::error::LibraryError::NotFound("duplicated playlist".into()))
+    }
+
+    // -----------------------------------------------------------------
+    // Crate operations
+    // -----------------------------------------------------------------
+
+    pub fn create_crate(&self, name: &str) -> Result<crate::models::Crate> {
+        let id = CrateDao::create(&self.db, name)?;
+        CrateDao::get_by_id(&self.db, id)?
+            .ok_or_else(|| crate::error::LibraryError::NotFound("crate just created".into()))
+    }
+
+    pub fn delete_crate(&self, id: i64) -> Result<()> {
+        CrateDao::delete(&self.db, id)
+    }
+
+    pub fn rename_crate(&self, id: i64, name: &str) -> Result<()> {
+        CrateDao::rename(&self.db, id, name)
+    }
+
+    pub fn crate_add_track(&self, crate_id: i64, track_id: i64) -> Result<()> {
+        CrateDao::add_track(&self.db, crate_id, track_id)
+    }
+
+    pub fn crate_remove_track(&self, crate_id: i64, track_id: i64) -> Result<()> {
+        CrateDao::remove_track(&self.db, crate_id, track_id)
+    }
+
+    pub fn crate_tracks(&self, crate_id: i64) -> Result<Vec<Track>> {
+        CrateDao::tracks(&self.db, crate_id)
+    }
+
+    pub fn list_crates(&self) -> Result<Vec<CrateSummary>> {
+        CrateDao::list_with_counts(&self.db)
+    }
+
+    // -----------------------------------------------------------------
+    // Playlist import
+    // -----------------------------------------------------------------
+
+    pub fn import_m3u(&self, path: &Path, playlist_name: &str) -> Result<ImportResult> {
+        import::import_m3u(&self.db, path, playlist_name)
+    }
+
+    pub fn import_pls(&self, path: &Path, playlist_name: &str) -> Result<ImportResult> {
+        import::import_pls(&self.db, path, playlist_name)
+    }
+}

--- a/crates/rustymixer-library/src/models.rs
+++ b/crates/rustymixer-library/src/models.rs
@@ -152,6 +152,17 @@ pub struct Playlist {
     pub is_locked: bool,
 }
 
+/// Playlist with its track count, returned by listing operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlaylistSummary {
+    pub id: i64,
+    pub name: String,
+    pub position: i32,
+    pub created_at: i64,
+    pub is_locked: bool,
+    pub track_count: usize,
+}
+
 // ---------------------------------------------------------------------------
 // Crate
 // ---------------------------------------------------------------------------
@@ -161,6 +172,26 @@ pub struct Crate {
     pub id: i64,
     pub name: String,
     pub created_at: i64,
+}
+
+/// Crate with its track count, returned by listing operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CrateSummary {
+    pub id: i64,
+    pub name: String,
+    pub created_at: i64,
+    pub track_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Import
+// ---------------------------------------------------------------------------
+
+/// Result of importing a playlist file (M3U or PLS).
+#[derive(Debug, Clone)]
+pub struct ImportResult {
+    pub imported: usize,
+    pub not_found: usize,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rustymixer-library/src/scanner.rs
+++ b/crates/rustymixer-library/src/scanner.rs
@@ -1,0 +1,427 @@
+//! Background library scanner — recursively scans music directories,
+//! reads metadata, and inserts/updates tracks in the database.
+//! Supports incremental scanning (only processes new/modified files).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use crossbeam::channel::{self, Receiver};
+use rusqlite::Connection;
+use tracing::{debug, info, warn};
+
+use crate::dao::{DirectoryDao, LocationDao, TrackDao};
+use crate::error::Result;
+use crate::metadata::MetadataReader;
+use crate::models::{NewTrack, NewTrackLocation};
+
+/// Audio file extensions the scanner recognises.
+const AUDIO_EXTENSIONS: &[&str] = &[
+    "mp3", "flac", "ogg", "opus", "m4a", "aac", "wav", "aiff", "wv",
+];
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Phase of a scan operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScanPhase {
+    /// Walking directory tree to discover audio files.
+    Discovering,
+    /// Reading metadata from discovered files.
+    Reading,
+    /// Checking for files removed from disk.
+    Verifying,
+}
+
+/// Progress update emitted during a scan.
+#[derive(Debug, Clone)]
+pub struct ScanProgress {
+    pub phase: ScanPhase,
+    pub current: usize,
+    pub total: usize,
+    pub current_file: Option<String>,
+}
+
+/// Summary returned when a scan completes.
+#[derive(Debug, Clone)]
+pub struct ScanResult {
+    pub added: usize,
+    pub updated: usize,
+    pub removed: usize,
+    pub errors: usize,
+    pub duration_secs: f64,
+}
+
+/// Handle returned by [`spawn_scan`] to monitor a background scan.
+pub struct ScanHandle {
+    handle: std::thread::JoinHandle<Result<ScanResult>>,
+    progress_rx: Receiver<ScanProgress>,
+}
+
+impl ScanHandle {
+    /// Non-blocking receiver for progress updates.
+    pub fn progress(&self) -> &Receiver<ScanProgress> {
+        &self.progress_rx
+    }
+
+    /// Check if the background scan thread has finished.
+    pub fn is_finished(&self) -> bool {
+        self.handle.is_finished()
+    }
+
+    /// Block until the scan thread finishes and return its result.
+    pub fn join(self) -> Result<ScanResult> {
+        self.handle.join().expect("scanner thread panicked")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LibraryScanner
+// ---------------------------------------------------------------------------
+
+/// Scans music directories and populates the database.
+pub struct LibraryScanner<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> LibraryScanner<'a> {
+    pub fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Scan all directories registered in the database.
+    pub fn scan_all(&self, progress: impl Fn(ScanProgress)) -> Result<ScanResult> {
+        let dirs = DirectoryDao::list(self.conn)?;
+        let mut combined = ScanResult {
+            added: 0,
+            updated: 0,
+            removed: 0,
+            errors: 0,
+            duration_secs: 0.0,
+        };
+        for dir in &dirs {
+            let result = self.scan_directory(Path::new(&dir.path), dir.id, &progress)?;
+            combined.added += result.added;
+            combined.updated += result.updated;
+            combined.removed += result.removed;
+            combined.errors += result.errors;
+            combined.duration_secs += result.duration_secs;
+        }
+        Ok(combined)
+    }
+
+    /// Scan a single directory (must already be registered with [`DirectoryDao`]).
+    pub fn scan_directory(
+        &self,
+        path: &Path,
+        dir_id: i64,
+        progress: &impl Fn(ScanProgress),
+    ) -> Result<ScanResult> {
+        let start = Instant::now();
+        let mut added = 0usize;
+        let mut updated = 0usize;
+        let mut removed = 0usize;
+        let mut errors = 0usize;
+
+        // --- Phase 1: Discover audio files ---
+        progress(ScanProgress {
+            phase: ScanPhase::Discovering,
+            current: 0,
+            total: 0,
+            current_file: None,
+        });
+
+        let audio_files = discover_audio_files(path);
+        let total = audio_files.len();
+
+        info!(directory = %path.display(), files = total, "discovery complete");
+
+        // --- Phase 2: Read metadata & insert/update ---
+        let now_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        // Track which relative filenames we saw on disk so we can detect removals.
+        let mut seen_filenames: HashSet<String> = HashSet::with_capacity(total);
+
+        for (i, file_path) in audio_files.iter().enumerate() {
+            let relative = match file_path.strip_prefix(path) {
+                Ok(r) => r.to_string_lossy().to_string(),
+                Err(_) => {
+                    warn!(path = %file_path.display(), "cannot compute relative path, skipping");
+                    errors += 1;
+                    continue;
+                }
+            };
+
+            progress(ScanProgress {
+                phase: ScanPhase::Reading,
+                current: i + 1,
+                total,
+                current_file: Some(relative.clone()),
+            });
+
+            seen_filenames.insert(relative.clone());
+
+            // Get file system metadata (size, mtime).
+            let fs_meta = match std::fs::metadata(file_path) {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(path = %file_path.display(), error = %e, "cannot stat file");
+                    errors += 1;
+                    continue;
+                }
+            };
+            let fs_modified = fs_meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64);
+            let filesize = Some(fs_meta.len() as i64);
+
+            // Check if already in DB.
+            let existing_loc = LocationDao::find(self.conn, dir_id, &relative)?;
+
+            match existing_loc {
+                Some(loc) if loc.fs_modified_at == fs_modified => {
+                    // Unchanged — skip.
+                    debug!(file = %relative, "unchanged, skipping");
+                }
+                Some(mut loc) => {
+                    // File modified — re-read metadata and update.
+                    debug!(file = %relative, "modified, updating");
+                    match MetadataReader::read(file_path) {
+                        Ok(meta) => {
+                            // Update location.
+                            loc.filesize = filesize;
+                            loc.fs_modified_at = fs_modified;
+                            loc.needs_verification = false;
+                            LocationDao::update(self.conn, &loc)?;
+
+                            // Update track metadata.
+                            if let Some(mut track) =
+                                TrackDao::get_by_location(self.conn, dir_id, &relative)?
+                            {
+                                track.title = meta.title;
+                                track.artist = meta.artist;
+                                track.album = meta.album;
+                                track.album_artist = meta.album_artist;
+                                track.genre = meta.genre;
+                                track.year = meta.year;
+                                track.track_number = meta.track_number;
+                                track.comment = meta.comment;
+                                track.duration_secs = meta.duration_secs;
+                                track.sample_rate = Some(meta.sample_rate as i32);
+                                track.channels = Some(meta.channels as i32);
+                                track.bitrate = meta.bitrate.map(|b| b as i32);
+                                track.bpm = meta.bpm;
+                                track.key = meta.key;
+                                track.replay_gain = meta.replay_gain;
+                                TrackDao::update(self.conn, &track)?;
+                            }
+                            updated += 1;
+                        }
+                        Err(e) => {
+                            warn!(file = %relative, error = %e, "metadata read failed on update");
+                            errors += 1;
+                        }
+                    }
+                }
+                None => {
+                    // New file — read metadata and insert.
+                    debug!(file = %relative, "new file, inserting");
+                    match MetadataReader::read(file_path) {
+                        Ok(meta) => {
+                            let loc_id = LocationDao::insert(
+                                self.conn,
+                                &NewTrackLocation {
+                                    directory_id: dir_id,
+                                    filename: relative.clone(),
+                                    filesize,
+                                    fs_modified_at: fs_modified,
+                                },
+                            )?;
+
+                            let new_track = NewTrack {
+                                location_id: Some(loc_id),
+                                title: meta.title,
+                                artist: meta.artist,
+                                album: meta.album,
+                                album_artist: meta.album_artist,
+                                genre: meta.genre,
+                                year: meta.year,
+                                track_number: meta.track_number,
+                                comment: meta.comment,
+                                duration_secs: meta.duration_secs,
+                                sample_rate: Some(meta.sample_rate as i32),
+                                channels: Some(meta.channels as i32),
+                                bitrate: meta.bitrate.map(|b| b as i32),
+                                bpm: meta.bpm,
+                                key: meta.key,
+                                rating: 0,
+                                replay_gain: meta.replay_gain,
+                                added_at: now_ts,
+                                cover_art_hash: None,
+                            };
+                            TrackDao::insert(self.conn, &new_track)?;
+                            added += 1;
+                        }
+                        Err(e) => {
+                            warn!(file = %relative, error = %e, "metadata read failed on insert");
+                            errors += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Phase 3: Verify — mark missing files ---
+        let db_locations = LocationDao::list_by_directory(self.conn, dir_id)?;
+        let verify_total = db_locations.len();
+
+        for (i, loc) in db_locations.iter().enumerate() {
+            progress(ScanProgress {
+                phase: ScanPhase::Verifying,
+                current: i + 1,
+                total: verify_total,
+                current_file: Some(loc.filename.clone()),
+            });
+
+            if !seen_filenames.contains(&loc.filename) {
+                // File is in DB but was not found on disk.
+                let full_path = path.join(&loc.filename);
+                if !full_path.exists() {
+                    debug!(file = %loc.filename, "marking as missing");
+                    LocationDao::mark_needs_verification(self.conn, loc.id)?;
+                    removed += 1;
+                }
+            }
+        }
+
+        let duration_secs = start.elapsed().as_secs_f64();
+
+        info!(
+            directory = %path.display(),
+            added, updated, removed, errors, duration_secs,
+            "scan complete"
+        );
+
+        Ok(ScanResult {
+            added,
+            updated,
+            removed,
+            errors,
+            duration_secs,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Background scanning
+// ---------------------------------------------------------------------------
+
+/// Spawn a scan of the given directories in a background thread.
+///
+/// Each directory is registered via [`DirectoryDao::add`] if not already present.
+/// Returns a [`ScanHandle`] to monitor progress and collect the result.
+pub fn spawn_scan(db_path: PathBuf, directories: Vec<PathBuf>) -> ScanHandle {
+    let (progress_tx, progress_rx) = channel::bounded(100);
+
+    let handle = std::thread::spawn(move || {
+        let db = crate::db::Database::open(&db_path)?;
+        let conn = db.conn();
+        let scanner = LibraryScanner::new(conn);
+        let mut combined = ScanResult {
+            added: 0,
+            updated: 0,
+            removed: 0,
+            errors: 0,
+            duration_secs: 0.0,
+        };
+
+        for dir in &directories {
+            let dir_str = dir.to_string_lossy();
+            let dir_id = DirectoryDao::add(conn, &dir_str)?;
+
+            let result = scanner.scan_directory(dir, dir_id, &|p| {
+                let _ = progress_tx.try_send(p);
+            })?;
+
+            combined.added += result.added;
+            combined.updated += result.updated;
+            combined.removed += result.removed;
+            combined.errors += result.errors;
+            combined.duration_secs += result.duration_secs;
+        }
+
+        Ok(combined)
+    });
+
+    ScanHandle {
+        handle,
+        progress_rx,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Recursively discover all audio files under `root`.
+fn discover_audio_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    walk_dir(root, &mut files);
+    files.sort();
+    files
+}
+
+fn walk_dir(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            warn!(dir = %dir.display(), error = %e, "cannot read directory");
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_dir(&path, out);
+        } else if is_audio_file(&path) {
+            out.push(path);
+        }
+    }
+}
+
+fn is_audio_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| AUDIO_EXTENSIONS.contains(&ext.to_lowercase().as_str()))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_audio_file_accepts_known_extensions() {
+        assert!(is_audio_file(Path::new("track.mp3")));
+        assert!(is_audio_file(Path::new("track.FLAC")));
+        assert!(is_audio_file(Path::new("song.wav")));
+        assert!(is_audio_file(Path::new("song.m4a")));
+        assert!(is_audio_file(Path::new("song.ogg")));
+        assert!(is_audio_file(Path::new("deep/path/song.aiff")));
+    }
+
+    #[test]
+    fn is_audio_file_rejects_non_audio() {
+        assert!(!is_audio_file(Path::new("readme.txt")));
+        assert!(!is_audio_file(Path::new("cover.jpg")));
+        assert!(!is_audio_file(Path::new("no_ext")));
+    }
+}

--- a/crates/rustymixer-library/tests/integration.rs
+++ b/crates/rustymixer-library/tests/integration.rs
@@ -781,3 +781,397 @@ fn spawn_scan_background_thread() {
     let db = Database::open(&db_path).unwrap();
     assert_eq!(TrackDao::count(db.conn()).unwrap(), 1);
 }
+
+
+// ---------------------------------------------------------------------------
+// LibraryManager — Playlist management tests
+// ---------------------------------------------------------------------------
+
+/// Helper: create a LibraryManager from a raw in-memory Connection.
+fn manager_from_memory() -> LibraryManager {
+    use rusqlite::Connection;
+    let conn = Connection::open_in_memory().unwrap();
+    rustymixer_library::schema::MigrationManager::migrate(&conn).unwrap();
+    LibraryManager::new(conn)
+}
+
+/// Insert a sample track directly via DAO and return its id.
+fn insert_sample_track(mgr: &LibraryManager, title: &str) -> i64 {
+    let mut t = sample_new_track(1000);
+    t.title = Some(title.into());
+    TrackDao::insert(mgr.conn(), &t).unwrap()
+}
+
+#[test]
+fn manager_create_rename_delete_playlist() {
+    let mgr = manager_from_memory();
+    let pl = mgr.create_playlist("Friday Set").unwrap();
+    assert_eq!(pl.name, "Friday Set");
+
+    mgr.rename_playlist(pl.id, "Saturday Set").unwrap();
+    let summaries = mgr.list_playlists().unwrap();
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].name, "Saturday Set");
+    assert_eq!(summaries[0].track_count, 0);
+
+    mgr.delete_playlist(pl.id).unwrap();
+    assert!(mgr.list_playlists().unwrap().is_empty());
+}
+
+#[test]
+fn manager_playlist_add_remove_tracks() {
+    let mgr = manager_from_memory();
+    let pl = mgr.create_playlist("Test").unwrap();
+    let t1 = insert_sample_track(&mgr, "Track A");
+    let t2 = insert_sample_track(&mgr, "Track B");
+    let t3 = insert_sample_track(&mgr, "Track C");
+
+    mgr.playlist_add_track(pl.id, t1).unwrap();
+    mgr.playlist_add_track(pl.id, t2).unwrap();
+    mgr.playlist_add_track(pl.id, t3).unwrap();
+
+    let tracks = mgr.playlist_tracks(pl.id).unwrap();
+    assert_eq!(tracks.len(), 3);
+    assert_eq!(tracks[0].id, t1);
+    assert_eq!(tracks[1].id, t2);
+    assert_eq!(tracks[2].id, t3);
+
+    // Remove middle track.
+    mgr.playlist_remove_track(pl.id, t2).unwrap();
+    let tracks = mgr.playlist_tracks(pl.id).unwrap();
+    assert_eq!(tracks.len(), 2);
+
+    // List with counts.
+    let summaries = mgr.list_playlists().unwrap();
+    assert_eq!(summaries[0].track_count, 2);
+}
+
+#[test]
+fn manager_playlist_reorder_tracks() {
+    let mgr = manager_from_memory();
+    let pl = mgr.create_playlist("Reorder Test").unwrap();
+    let t1 = insert_sample_track(&mgr, "A");
+    let t2 = insert_sample_track(&mgr, "B");
+    let t3 = insert_sample_track(&mgr, "C");
+
+    mgr.playlist_add_track(pl.id, t1).unwrap();
+    mgr.playlist_add_track(pl.id, t2).unwrap();
+    mgr.playlist_add_track(pl.id, t3).unwrap();
+
+    // Move first track to last position: [A,B,C] -> [B,C,A]
+    mgr.playlist_move_track(pl.id, 0, 2).unwrap();
+    let tracks = mgr.playlist_tracks(pl.id).unwrap();
+    assert_eq!(tracks[0].id, t2);
+    assert_eq!(tracks[1].id, t3);
+    assert_eq!(tracks[2].id, t1);
+
+    // Move last track to first position: [B,C,A] -> [A,B,C]
+    mgr.playlist_move_track(pl.id, 2, 0).unwrap();
+    let tracks = mgr.playlist_tracks(pl.id).unwrap();
+    assert_eq!(tracks[0].id, t1);
+    assert_eq!(tracks[1].id, t2);
+    assert_eq!(tracks[2].id, t3);
+}
+
+#[test]
+fn manager_duplicate_playlist() {
+    let mgr = manager_from_memory();
+    let pl = mgr.create_playlist("Original").unwrap();
+    let t1 = insert_sample_track(&mgr, "Track 1");
+    let t2 = insert_sample_track(&mgr, "Track 2");
+
+    mgr.playlist_add_track(pl.id, t1).unwrap();
+    mgr.playlist_add_track(pl.id, t2).unwrap();
+
+    let dup = mgr.duplicate_playlist(pl.id, "Copy").unwrap();
+    assert_eq!(dup.name, "Copy");
+    assert_ne!(dup.id, pl.id);
+
+    let dup_tracks = mgr.playlist_tracks(dup.id).unwrap();
+    assert_eq!(dup_tracks.len(), 2);
+    assert_eq!(dup_tracks[0].id, t1);
+    assert_eq!(dup_tracks[1].id, t2);
+
+    // Originals still intact.
+    let orig_tracks = mgr.playlist_tracks(pl.id).unwrap();
+    assert_eq!(orig_tracks.len(), 2);
+}
+
+#[test]
+fn manager_playlist_cascade_delete() {
+    let mgr = manager_from_memory();
+    let pl = mgr.create_playlist("Cascade Test").unwrap();
+    let t1 = insert_sample_track(&mgr, "Track 1");
+    mgr.playlist_add_track(pl.id, t1).unwrap();
+
+    // Deleting playlist should cascade to playlist_tracks.
+    mgr.delete_playlist(pl.id).unwrap();
+
+    // The track itself should still exist.
+    let track = TrackDao::get_by_id(mgr.conn(), t1).unwrap();
+    assert!(track.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// LibraryManager — Crate management tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn manager_create_rename_delete_crate() {
+    let mgr = manager_from_memory();
+    let cr = mgr.create_crate("Favorites").unwrap();
+    assert_eq!(cr.name, "Favorites");
+
+    mgr.rename_crate(cr.id, "Top Picks").unwrap();
+    let summaries = mgr.list_crates().unwrap();
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].name, "Top Picks");
+    assert_eq!(summaries[0].track_count, 0);
+
+    mgr.delete_crate(cr.id).unwrap();
+    assert!(mgr.list_crates().unwrap().is_empty());
+}
+
+#[test]
+fn manager_crate_add_remove_tracks() {
+    let mgr = manager_from_memory();
+    let cr = mgr.create_crate("Techno").unwrap();
+    let t1 = insert_sample_track(&mgr, "Techno 1");
+    let t2 = insert_sample_track(&mgr, "Techno 2");
+
+    mgr.crate_add_track(cr.id, t1).unwrap();
+    mgr.crate_add_track(cr.id, t2).unwrap();
+
+    let tracks = mgr.crate_tracks(cr.id).unwrap();
+    assert_eq!(tracks.len(), 2);
+
+    // Adding same track again is idempotent.
+    mgr.crate_add_track(cr.id, t1).unwrap();
+    let tracks = mgr.crate_tracks(cr.id).unwrap();
+    assert_eq!(tracks.len(), 2);
+
+    mgr.crate_remove_track(cr.id, t1).unwrap();
+    let tracks = mgr.crate_tracks(cr.id).unwrap();
+    assert_eq!(tracks.len(), 1);
+    assert_eq!(tracks[0].id, t2);
+
+    // List with counts.
+    let summaries = mgr.list_crates().unwrap();
+    assert_eq!(summaries[0].track_count, 1);
+}
+
+#[test]
+fn manager_track_in_multiple_crates() {
+    let mgr = manager_from_memory();
+    let cr1 = mgr.create_crate("House").unwrap();
+    let cr2 = mgr.create_crate("Deep").unwrap();
+    let t1 = insert_sample_track(&mgr, "Shared Track");
+
+    mgr.crate_add_track(cr1.id, t1).unwrap();
+    mgr.crate_add_track(cr2.id, t1).unwrap();
+
+    assert_eq!(mgr.crate_tracks(cr1.id).unwrap().len(), 1);
+    assert_eq!(mgr.crate_tracks(cr2.id).unwrap().len(), 1);
+
+    // Removing from one crate doesn't affect the other.
+    mgr.crate_remove_track(cr1.id, t1).unwrap();
+    assert_eq!(mgr.crate_tracks(cr1.id).unwrap().len(), 0);
+    assert_eq!(mgr.crate_tracks(cr2.id).unwrap().len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// M3U / PLS import tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn import_m3u_with_valid_and_missing_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let mgr = manager_from_memory();
+
+    // Set up a track with a known file path in the library.
+    let dir_id = DirectoryDao::add(mgr.conn(), dir.path().to_str().unwrap()).unwrap();
+    let loc_id = LocationDao::insert(
+        mgr.conn(),
+        &NewTrackLocation {
+            directory_id: dir_id,
+            filename: "song.mp3".into(),
+            filesize: None,
+            fs_modified_at: None,
+        },
+    )
+    .unwrap();
+    let mut t = sample_new_track(1000);
+    t.location_id = Some(loc_id);
+    TrackDao::insert(mgr.conn(), &t).unwrap();
+
+    // Write an M3U file with one matching path and one missing.
+    let m3u_path = dir.path().join("test.m3u");
+    let m3u_content = format!(
+        "#EXTM3U\n# A comment\n{}/song.mp3\n/nonexistent/missing.mp3\n",
+        dir.path().display()
+    );
+    std::fs::write(&m3u_path, m3u_content).unwrap();
+
+    let result = mgr.import_m3u(&m3u_path, "Imported Playlist").unwrap();
+    assert_eq!(result.imported, 1);
+    assert_eq!(result.not_found, 1);
+
+    // Verify the playlist was created and has the track.
+    let summaries = mgr.list_playlists().unwrap();
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].name, "Imported Playlist");
+    assert_eq!(summaries[0].track_count, 1);
+}
+
+#[test]
+fn import_pls_with_valid_and_missing_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let mgr = manager_from_memory();
+
+    // Set up a track.
+    let dir_id = DirectoryDao::add(mgr.conn(), dir.path().to_str().unwrap()).unwrap();
+    let loc_id = LocationDao::insert(
+        mgr.conn(),
+        &NewTrackLocation {
+            directory_id: dir_id,
+            filename: "track.flac".into(),
+            filesize: None,
+            fs_modified_at: None,
+        },
+    )
+    .unwrap();
+    let mut t = sample_new_track(2000);
+    t.location_id = Some(loc_id);
+    TrackDao::insert(mgr.conn(), &t).unwrap();
+
+    // Write a PLS file.
+    let pls_path = dir.path().join("test.pls");
+    let pls_content = format!(
+        "[playlist]\nFile1={}/track.flac\nTitle1=My Track\nFile2=/gone/nowhere.mp3\nNumberOfEntries=2\nVersion=2\n",
+        dir.path().display()
+    );
+    std::fs::write(&pls_path, pls_content).unwrap();
+
+    let result = mgr.import_pls(&pls_path, "PLS Import").unwrap();
+    assert_eq!(result.imported, 1);
+    assert_eq!(result.not_found, 1);
+}
+
+// ---------------------------------------------------------------------------
+// DAO-level tests for new methods
+// ---------------------------------------------------------------------------
+
+#[test]
+fn playlist_dao_get_by_id() {
+    let db = test_db();
+    let c = db.conn();
+
+    let id = PlaylistDao::create(c, "Get By ID").unwrap();
+    let pl = PlaylistDao::get_by_id(c, id).unwrap().unwrap();
+    assert_eq!(pl.name, "Get By ID");
+    assert_eq!(pl.id, id);
+
+    assert!(PlaylistDao::get_by_id(c, 9999).unwrap().is_none());
+}
+
+#[test]
+fn playlist_dao_list_with_counts() {
+    let db = test_db();
+    let c = db.conn();
+
+    let pl1 = PlaylistDao::create(c, "Empty").unwrap();
+    let pl2 = PlaylistDao::create(c, "With Tracks").unwrap();
+    let t1 = TrackDao::insert(c, &sample_new_track(1000)).unwrap();
+    let t2 = TrackDao::insert(c, &sample_new_track(2000)).unwrap();
+    PlaylistDao::add_track(c, pl2, t1).unwrap();
+    PlaylistDao::add_track(c, pl2, t2).unwrap();
+
+    let summaries = PlaylistDao::list_with_counts(c).unwrap();
+    assert_eq!(summaries.len(), 2);
+
+    let empty = summaries.iter().find(|s| s.id == pl1).unwrap();
+    assert_eq!(empty.track_count, 0);
+
+    let with_tracks = summaries.iter().find(|s| s.id == pl2).unwrap();
+    assert_eq!(with_tracks.track_count, 2);
+}
+
+#[test]
+fn playlist_dao_move_track() {
+    let db = test_db();
+    let c = db.conn();
+
+    let pl = PlaylistDao::create(c, "Move Test").unwrap();
+    let t1 = TrackDao::insert(c, &sample_new_track(1000)).unwrap();
+    let t2 = TrackDao::insert(c, &sample_new_track(2000)).unwrap();
+    let t3 = TrackDao::insert(c, &sample_new_track(3000)).unwrap();
+
+    PlaylistDao::add_track(c, pl, t1).unwrap();
+    PlaylistDao::add_track(c, pl, t2).unwrap();
+    PlaylistDao::add_track(c, pl, t3).unwrap();
+
+    // [t1, t2, t3] -> move pos 0 to pos 2 -> [t2, t3, t1]
+    PlaylistDao::move_track(c, pl, 0, 2).unwrap();
+    let tracks = PlaylistDao::tracks(c, pl).unwrap();
+    assert_eq!(tracks[0].id, t2);
+    assert_eq!(tracks[1].id, t3);
+    assert_eq!(tracks[2].id, t1);
+
+    // No-op move.
+    PlaylistDao::move_track(c, pl, 1, 1).unwrap();
+    let tracks = PlaylistDao::tracks(c, pl).unwrap();
+    assert_eq!(tracks[1].id, t3); // unchanged
+}
+
+#[test]
+fn playlist_dao_duplicate() {
+    let db = test_db();
+    let c = db.conn();
+
+    let pl = PlaylistDao::create(c, "Original").unwrap();
+    let t1 = TrackDao::insert(c, &sample_new_track(1000)).unwrap();
+    PlaylistDao::add_track(c, pl, t1).unwrap();
+
+    let dup_id = PlaylistDao::duplicate(c, pl, "Clone").unwrap();
+    assert_ne!(dup_id, pl);
+
+    let dup = PlaylistDao::get_by_id(c, dup_id).unwrap().unwrap();
+    assert_eq!(dup.name, "Clone");
+
+    let dup_tracks = PlaylistDao::tracks(c, dup_id).unwrap();
+    assert_eq!(dup_tracks.len(), 1);
+    assert_eq!(dup_tracks[0].id, t1);
+}
+
+#[test]
+fn crate_dao_get_by_id() {
+    let db = test_db();
+    let c = db.conn();
+
+    let id = CrateDao::create(c, "My Crate").unwrap();
+    let cr = CrateDao::get_by_id(c, id).unwrap().unwrap();
+    assert_eq!(cr.name, "My Crate");
+    assert_eq!(cr.id, id);
+
+    assert!(CrateDao::get_by_id(c, 9999).unwrap().is_none());
+}
+
+#[test]
+fn crate_dao_list_with_counts() {
+    let db = test_db();
+    let c = db.conn();
+
+    let cr1 = CrateDao::create(c, "Empty Crate").unwrap();
+    let cr2 = CrateDao::create(c, "Full Crate").unwrap();
+    let t1 = TrackDao::insert(c, &sample_new_track(1000)).unwrap();
+    CrateDao::add_track(c, cr2, t1).unwrap();
+
+    let summaries = CrateDao::list_with_counts(c).unwrap();
+    assert_eq!(summaries.len(), 2);
+
+    let empty = summaries.iter().find(|s| s.id == cr1).unwrap();
+    assert_eq!(empty.track_count, 0);
+
+    let full = summaries.iter().find(|s| s.id == cr2).unwrap();
+    assert_eq!(full.track_count, 1);
+}

--- a/crates/rustymixer-library/tests/integration.rs
+++ b/crates/rustymixer-library/tests/integration.rs
@@ -460,3 +460,324 @@ fn metadata_read_missing_file() {
     let result = MetadataReader::read(Path::new("/tmp/does_not_exist_9999.mp3"));
     assert!(result.is_err());
 }
+
+// ---------------------------------------------------------------------------
+// Scanner tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scanner_scan_directory_with_audio_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    // Copy the fixture WAV file into the music directory.
+    let fixture = fixture_path("silence.wav");
+    std::fs::copy(&fixture, music_dir.join("track1.wav")).unwrap();
+    std::fs::copy(&fixture, music_dir.join("track2.wav")).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    let dir_id = DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+
+    let scanner = LibraryScanner::new(c);
+    let result = scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+
+    assert_eq!(result.added, 2);
+    assert_eq!(result.updated, 0);
+    assert_eq!(result.removed, 0);
+    assert_eq!(result.errors, 0);
+    assert!(result.duration_secs >= 0.0);
+
+    // Verify tracks are in DB.
+    assert_eq!(TrackDao::count(c).unwrap(), 2);
+}
+
+#[test]
+fn scanner_incremental_scan_skips_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    let fixture = fixture_path("silence.wav");
+    std::fs::copy(&fixture, music_dir.join("track1.wav")).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    let dir_id = DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+
+    let scanner = LibraryScanner::new(c);
+
+    // First scan — should add one track.
+    let r1 = scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+    assert_eq!(r1.added, 1);
+
+    // Second scan — nothing changed, so zero added/updated.
+    let r2 = scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+    assert_eq!(r2.added, 0);
+    assert_eq!(r2.updated, 0);
+
+    // Still only one track in DB.
+    assert_eq!(TrackDao::count(c).unwrap(), 1);
+}
+
+#[test]
+fn scanner_detects_modified_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    let fixture = fixture_path("silence.wav");
+    let target = music_dir.join("track.wav");
+    std::fs::copy(&fixture, &target).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    let dir_id = DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+    let scanner = LibraryScanner::new(c);
+
+    // First scan.
+    scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+
+    // Simulate modification by changing mtime stored in DB.
+    let loc = LocationDao::find(c, dir_id, "track.wav").unwrap().unwrap();
+    let mut loc_modified = loc;
+    loc_modified.fs_modified_at = Some(0); // Force mismatch.
+    LocationDao::update(c, &loc_modified).unwrap();
+
+    // Second scan should detect the mtime mismatch and re-read.
+    let r2 = scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+    assert_eq!(r2.updated, 1);
+    assert_eq!(r2.added, 0);
+}
+
+#[test]
+fn scanner_detects_missing_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    let fixture = fixture_path("silence.wav");
+    let target = music_dir.join("track.wav");
+    std::fs::copy(&fixture, &target).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    let dir_id = DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+    let scanner = LibraryScanner::new(c);
+
+    // First scan.
+    scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+
+    // Delete the file from disk.
+    std::fs::remove_file(&target).unwrap();
+
+    // Second scan should detect the missing file.
+    let r2 = scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+    assert_eq!(r2.removed, 1);
+
+    // Location should be marked needs_verification.
+    let loc = LocationDao::find(c, dir_id, "track.wav").unwrap().unwrap();
+    assert!(loc.needs_verification);
+}
+
+#[test]
+fn scanner_empty_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    let dir_id = DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+
+    let scanner = LibraryScanner::new(c);
+    let result = scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+
+    assert_eq!(result.added, 0);
+    assert_eq!(result.updated, 0);
+    assert_eq!(result.removed, 0);
+    assert_eq!(result.errors, 0);
+    assert_eq!(TrackDao::count(c).unwrap(), 0);
+}
+
+#[test]
+fn scanner_progress_reporting() {
+    use std::cell::RefCell;
+
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    let fixture = fixture_path("silence.wav");
+    std::fs::copy(&fixture, music_dir.join("a.wav")).unwrap();
+    std::fs::copy(&fixture, music_dir.join("b.wav")).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    let dir_id = DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+    let scanner = LibraryScanner::new(c);
+
+    let progress_updates = RefCell::new(Vec::new());
+    scanner
+        .scan_directory(&music_dir, dir_id, &|p| {
+            progress_updates.borrow_mut().push(p);
+        })
+        .unwrap();
+    let progress_updates = progress_updates.into_inner();
+
+    // Should have at least: 1 Discovering + 2 Reading + 2 Verifying.
+    assert!(progress_updates.len() >= 5);
+
+    // First update should be Discovering phase.
+    assert_eq!(progress_updates[0].phase, ScanPhase::Discovering);
+
+    // Should have Reading phases.
+    let reading = progress_updates
+        .iter()
+        .filter(|p| p.phase == ScanPhase::Reading)
+        .count();
+    assert_eq!(reading, 2);
+
+    // Should have Verifying phases.
+    let verifying = progress_updates
+        .iter()
+        .filter(|p| p.phase == ScanPhase::Verifying)
+        .count();
+    assert_eq!(verifying, 2);
+}
+
+#[test]
+fn scanner_scan_all_uses_registered_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    let fixture = fixture_path("silence.wav");
+    std::fs::copy(&fixture, music_dir.join("track.wav")).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+
+    let scanner = LibraryScanner::new(c);
+    let result = scanner.scan_all(|_| {}).unwrap();
+
+    assert_eq!(result.added, 1);
+    assert_eq!(TrackDao::count(c).unwrap(), 1);
+}
+
+#[test]
+fn scanner_ignores_non_audio_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    // Create non-audio files.
+    std::fs::write(music_dir.join("readme.txt"), "hello").unwrap();
+    std::fs::write(music_dir.join("cover.jpg"), &[0xFF, 0xD8]).unwrap();
+
+    // Also copy a real audio file.
+    let fixture = fixture_path("silence.wav");
+    std::fs::copy(&fixture, music_dir.join("track.wav")).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    let dir_id = DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+
+    let scanner = LibraryScanner::new(c);
+    let result = scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+
+    // Only the WAV file should be added.
+    assert_eq!(result.added, 1);
+    assert_eq!(TrackDao::count(c).unwrap(), 1);
+}
+
+#[test]
+fn scanner_recursive_subdirectory() {
+    let dir = tempfile::tempdir().unwrap();
+    let music_dir = dir.path().join("music");
+    let subdir = music_dir.join("album");
+    std::fs::create_dir_all(&subdir).unwrap();
+
+    let fixture = fixture_path("silence.wav");
+    std::fs::copy(&fixture, music_dir.join("track1.wav")).unwrap();
+    std::fs::copy(&fixture, subdir.join("track2.wav")).unwrap();
+
+    let db = test_db();
+    let c = db.conn();
+    let dir_id = DirectoryDao::add(c, &music_dir.to_string_lossy()).unwrap();
+
+    let scanner = LibraryScanner::new(c);
+    let result = scanner
+        .scan_directory(&music_dir, dir_id, &|_| {})
+        .unwrap();
+
+    // Both tracks (root and subdirectory) should be added.
+    assert_eq!(result.added, 2);
+    assert_eq!(TrackDao::count(c).unwrap(), 2);
+}
+
+#[test]
+fn spawn_scan_background_thread() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let music_dir = dir.path().join("music");
+    std::fs::create_dir(&music_dir).unwrap();
+
+    let fixture = fixture_path("silence.wav");
+    std::fs::copy(&fixture, music_dir.join("track.wav")).unwrap();
+
+    // Ensure the database is initialized.
+    {
+        let _db = Database::open(&db_path).unwrap();
+    }
+
+    let handle = spawn_scan(db_path.clone(), vec![music_dir]);
+
+    // Drain progress updates.
+    let mut progress_count = 0;
+    loop {
+        match handle.progress().try_recv() {
+            Ok(_) => progress_count += 1,
+            Err(crossbeam::channel::TryRecvError::Empty) => {
+                // Check if thread is still running.
+                if handle.is_finished() {
+                    // Drain remaining.
+                    while handle.progress().try_recv().is_ok() {
+                        progress_count += 1;
+                    }
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(crossbeam::channel::TryRecvError::Disconnected) => break,
+        }
+    }
+
+    let result = handle.join().unwrap();
+    assert_eq!(result.added, 1);
+    assert!(progress_count > 0);
+
+    // Verify the track was actually persisted.
+    let db = Database::open(&db_path).unwrap();
+    assert_eq!(TrackDao::count(db.conn()).unwrap(), 1);
+}

--- a/crates/rustymixer-ui/Cargo.toml
+++ b/crates/rustymixer-ui/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 rustymixer-core = { workspace = true }
+rustymixer-engine = { workspace = true }
 rustymixer-decode = { workspace = true }
 rustymixer-io = { workspace = true }
 dioxus = { workspace = true }

--- a/crates/rustymixer-ui/src/engine.rs
+++ b/crates/rustymixer-ui/src/engine.rs
@@ -1,66 +1,120 @@
-//! Background audio engine — decodes audio and writes to the output device.
+//! Two-deck audio engine using EngineBuffer, Crossfader, and CpalOutput.
 //!
-//! The engine runs on a dedicated thread and communicates with the UI via
-//! a crossbeam channel (commands in) and shared state (status out).
+//! The engine runs on a dedicated thread. The UI sends commands via crossbeam
+//! channels. Each deck is an EngineBuffer managed directly (not via EngineMixer)
+//! so we can read playback state back to the UI.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crossbeam::channel::Receiver;
-use rustymixer_decode::{AudioDecoder, SymphoniaDecoder};
+use crossbeam::channel::{Receiver, Sender};
+use rustymixer_core::audio::FramePos;
+use rustymixer_engine::{
+    apply_gain, AtomicF32, ChannelId, ChannelOrientation, Crossfader, EngineBuffer,
+    EngineChannel, PlaybackState,
+};
 use rustymixer_io::{AudioConfig, AudioOutput, CpalOutput};
 
-/// Commands sent from the UI to the audio engine.
-pub enum PlayerCommand {
-    Load(PathBuf),
+/// Commands sent from the UI to a specific deck.
+pub enum DeckCommand {
+    LoadTrack(PathBuf),
     Play,
     Pause,
     Stop,
     Seek(f64),
-    SetVolume(f32),
+    SetRate(f32),
+    SetGain(f32),
 }
 
-/// State shared between the engine thread and the UI.
-pub struct SharedState {
-    pub is_playing: bool,
+/// Per-deck state visible to the UI.
+#[derive(Debug, Clone)]
+pub struct DeckState {
+    pub state: PlaybackState,
     pub position_secs: f64,
     pub duration_secs: f64,
     pub volume: f32,
+    pub rate: f32,
     pub track_title: String,
     pub track_artist: String,
     pub loaded: bool,
+    pub sample_rate: u32,
+    pub total_frames: u64,
+}
+
+impl Default for DeckState {
+    fn default() -> Self {
+        Self {
+            state: PlaybackState::Empty,
+            position_secs: 0.0,
+            duration_secs: 0.0,
+            volume: 0.8,
+            rate: 1.0,
+            track_title: String::new(),
+            track_artist: String::new(),
+            loaded: false,
+            sample_rate: 44100,
+            total_frames: 0,
+        }
+    }
+}
+
+/// Shared state between the engine thread and the UI.
+pub struct SharedState {
+    pub decks: [DeckState; 2],
+    pub crossfader: f32,
+    pub master_volume: f32,
     pub error: Option<String>,
 }
 
 impl Default for SharedState {
     fn default() -> Self {
         Self {
-            is_playing: false,
-            position_secs: 0.0,
-            duration_secs: 0.0,
-            volume: 0.8,
-            track_title: String::new(),
-            track_artist: String::new(),
-            loaded: false,
+            decks: [DeckState::default(), DeckState::default()],
+            crossfader: 0.0,
+            master_volume: 0.8,
             error: None,
         }
     }
 }
 
-/// Spawn the audio engine on a named background thread.
-pub fn spawn_engine(rx: Receiver<PlayerCommand>, state: Arc<Mutex<SharedState>>) {
+const PROCESS_FRAMES: usize = 1024;
+
+/// Spawn the two-deck audio engine.
+///
+/// Returns per-deck command senders for the UI.
+pub fn spawn_engine(
+    state: Arc<Mutex<SharedState>>,
+    crossfader: Arc<Crossfader>,
+    master_gain: Arc<AtomicF32>,
+) -> [Sender<DeckCommand>; 2] {
+    let (tx_a, rx_a) = crossbeam::channel::unbounded::<DeckCommand>();
+    let (tx_b, rx_b) = crossbeam::channel::unbounded::<DeckCommand>();
+
     std::thread::Builder::new()
         .name("audio-engine".into())
-        .spawn(move || engine_loop(rx, state))
+        .spawn(move || {
+            engine_loop(rx_a, rx_b, state, crossfader, master_gain);
+        })
         .expect("failed to spawn audio engine thread");
+
+    [tx_a, tx_b]
 }
 
-/// Number of stereo frames to decode per iteration.
-const DECODE_FRAMES: usize = 1024;
+fn engine_loop(
+    rx_a: Receiver<DeckCommand>,
+    rx_b: Receiver<DeckCommand>,
+    state: Arc<Mutex<SharedState>>,
+    crossfader: Arc<Crossfader>,
+    master_gain: Arc<AtomicF32>,
+) {
+    // Create the two deck buffers and their handles.
+    let (mut deck_a, handle_a) = EngineBuffer::new(ChannelId(0));
+    let (mut deck_b, handle_b) = EngineBuffer::new(ChannelId(1));
+    deck_a.set_orientation(ChannelOrientation::Left);
+    deck_b.set_orientation(ChannelOrientation::Right);
 
-fn engine_loop(rx: Receiver<PlayerCommand>, state: Arc<Mutex<SharedState>>) {
-    // Create and start the audio output once.
+    // Start audio output.
     let config = AudioConfig::default();
     let mut output: Option<CpalOutput> = match CpalOutput::new(config) {
         Ok(mut out) => match out.start() {
@@ -78,126 +132,116 @@ fn engine_loop(rx: Receiver<PlayerCommand>, state: Arc<Mutex<SharedState>>) {
         }
     };
 
-    let mut decoder: Option<SymphoniaDecoder> = None;
-    let mut playing = false;
-    let mut volume: f32 = 0.8;
-    let mut buf = vec![0.0f32; DECODE_FRAMES * 2];
+    let mut buf_a = vec![0.0f32; PROCESS_FRAMES * 2];
+    let mut buf_b = vec![0.0f32; PROCESS_FRAMES * 2];
+    let mut mix_buf = vec![0.0f32; PROCESS_FRAMES * 2];
 
     loop {
-        // Drain all pending commands.
-        while let Ok(cmd) = rx.try_recv() {
-            match cmd {
-                PlayerCommand::Load(path) => {
-                    playing = false;
-                    match SymphoniaDecoder::open(&path) {
-                        Ok(dec) => {
-                            let info = dec.track_info();
-                            let duration = info
-                                .total_frames
-                                .map(|f| f as f64 / info.sample_rate as f64)
-                                .unwrap_or(0.0);
-                            let title = info.title.clone().unwrap_or_else(|| {
-                                path.file_stem()
-                                    .map(|n| n.to_string_lossy().into_owned())
-                                    .unwrap_or_default()
-                            });
-                            let artist = info.artist.clone().unwrap_or_default();
-                            {
-                                let mut s = state.lock().unwrap();
-                                s.track_title = title;
-                                s.track_artist = artist;
-                                s.duration_secs = duration;
-                                s.position_secs = 0.0;
-                                s.loaded = true;
-                                s.is_playing = false;
-                                s.error = None;
-                            }
-                            decoder = Some(dec);
-                            tracing::info!("loaded {}", path.display());
-                        }
-                        Err(e) => {
-                            tracing::error!("failed to open {}: {e}", path.display());
-                            state.lock().unwrap().error =
-                                Some(format!("Failed to open file: {e}"));
-                        }
-                    }
-                }
-                PlayerCommand::Play => {
-                    if decoder.is_some() && output.is_some() {
-                        playing = true;
-                        state.lock().unwrap().is_playing = true;
-                    }
-                }
-                PlayerCommand::Pause => {
-                    playing = false;
-                    state.lock().unwrap().is_playing = false;
-                }
-                PlayerCommand::Stop => {
-                    playing = false;
-                    if let Some(ref mut dec) = decoder {
-                        let _ = dec.seek(0);
-                    }
-                    let mut s = state.lock().unwrap();
-                    s.is_playing = false;
-                    s.position_secs = 0.0;
-                }
-                PlayerCommand::Seek(secs) => {
-                    if let Some(ref mut dec) = decoder {
-                        let sr = dec.track_info().sample_rate;
-                        let frame = (secs * sr as f64) as u64;
-                        if dec.seek(frame).is_ok() {
-                            state.lock().unwrap().position_secs = secs;
-                        }
-                    }
-                }
-                PlayerCommand::SetVolume(v) => {
-                    volume = v;
-                    state.lock().unwrap().volume = v;
-                }
-            }
+        // Drain UI commands for each deck.
+        process_deck_commands(&rx_a, &handle_a, &state);
+        process_deck_commands(&rx_b, &handle_b, &state);
+
+        let frames = PROCESS_FRAMES;
+        let samples = frames * 2;
+
+        // Process each deck.
+        buf_a[..samples].fill(0.0);
+        buf_b[..samples].fill(0.0);
+        let active_a = deck_a.process(&mut buf_a[..samples], frames);
+        let active_b = deck_b.process(&mut buf_b[..samples], frames);
+
+        // Apply crossfader gains.
+        let (xf_left, xf_right) = crossfader.gains();
+        if active_a {
+            apply_gain(&mut buf_a[..samples], deck_a.gain() * xf_left);
+        }
+        if active_b {
+            apply_gain(&mut buf_b[..samples], deck_b.gain() * xf_right);
         }
 
-        if playing {
-            if let (Some(ref mut dec), Some(ref mut out)) = (&mut decoder, &mut output) {
-                match dec.read_frames(&mut buf, DECODE_FRAMES) {
-                    Ok(0) => {
-                        // End of track.
-                        playing = false;
-                        let mut s = state.lock().unwrap();
-                        s.is_playing = false;
-                    }
-                    Ok(frames) => {
-                        let samples = &mut buf[..frames * 2];
-                        // Apply volume gain.
-                        for s in samples.iter_mut() {
-                            *s *= volume;
-                        }
-                        // Write all samples to the ring buffer, busy-waiting if full.
-                        let mut offset = 0;
-                        while offset < samples.len() {
-                            let n = out.write(&samples[offset..]);
-                            offset += n;
-                            if n == 0 {
-                                std::thread::sleep(Duration::from_millis(1));
-                            }
-                        }
-                        // Update position.
-                        let sr = dec.track_info().sample_rate;
-                        state.lock().unwrap().position_secs =
-                            dec.position() as f64 / sr as f64;
-                    }
-                    Err(e) => {
-                        tracing::error!("decode error: {e}");
-                        playing = false;
-                        let mut s = state.lock().unwrap();
-                        s.is_playing = false;
-                        s.error = Some(format!("Playback error: {e}"));
-                    }
+        // Mix and apply master gain.
+        let mg = master_gain.load(std::sync::atomic::Ordering::Relaxed);
+        for i in 0..samples {
+            mix_buf[i] = (buf_a[i] + buf_b[i]) * mg;
+        }
+
+        // Write to audio output.
+        if let Some(ref mut out) = output {
+            let mut offset = 0;
+            while offset < samples {
+                let n = out.write(&mix_buf[offset..samples]);
+                offset += n;
+                if n == 0 {
+                    std::thread::sleep(Duration::from_millis(1));
                 }
             }
         } else {
-            // Not playing — avoid busy-waiting.
             std::thread::sleep(Duration::from_millis(10));
         }
+
+        // Update shared state.
+        if let Ok(mut s) = state.try_lock() {
+            update_deck_state(&deck_a, &mut s.decks[0]);
+            update_deck_state(&deck_b, &mut s.decks[1]);
+            s.crossfader = crossfader.position();
+            s.master_volume = mg;
+        }
+    }
+}
+
+fn process_deck_commands(
+    rx: &Receiver<DeckCommand>,
+    handle: &rustymixer_engine::EngineBufferHandle,
+    state: &Arc<Mutex<SharedState>>,
+) {
+    while let Ok(cmd) = rx.try_recv() {
+        match cmd {
+            DeckCommand::LoadTrack(path) => {
+                if let Err(e) = handle.load_track(&path) {
+                    tracing::error!("failed to load track: {e}");
+                    if let Ok(mut s) = state.lock() {
+                        s.error = Some(format!("Failed to load: {e}"));
+                    }
+                }
+            }
+            DeckCommand::Play => handle.play(),
+            DeckCommand::Pause => handle.pause(),
+            DeckCommand::Stop => handle.stop(),
+            DeckCommand::Seek(frame) => handle.seek(FramePos::new(frame)),
+            DeckCommand::SetRate(r) => handle.set_rate(r),
+            DeckCommand::SetGain(g) => handle.set_gain(g),
+        }
+    }
+}
+
+fn update_deck_state(deck: &EngineBuffer, ds: &mut DeckState) {
+    ds.state = deck.state();
+    ds.volume = deck.gain();
+    ds.rate = deck.rate();
+
+    if let Some(info) = deck.track_info() {
+        ds.loaded = true;
+        ds.sample_rate = info.sample_rate;
+        ds.total_frames = info.total_frames.unwrap_or(0);
+        ds.duration_secs = if info.sample_rate > 0 {
+            ds.total_frames as f64 / info.sample_rate as f64
+        } else {
+            0.0
+        };
+        ds.track_title = info.title.clone().unwrap_or_default();
+        ds.track_artist = info.artist.clone().unwrap_or_default();
+        ds.position_secs = if info.sample_rate > 0 {
+            deck.play_pos().value() / info.sample_rate as f64
+        } else {
+            0.0
+        };
+    } else {
+        ds.loaded = false;
+        ds.state = PlaybackState::Empty;
+        ds.position_secs = 0.0;
+        ds.duration_secs = 0.0;
+        ds.track_title.clear();
+        ds.track_artist.clear();
+        ds.total_frames = 0;
     }
 }

--- a/crates/rustymixer-ui/src/main.rs
+++ b/crates/rustymixer-ui/src/main.rs
@@ -1,12 +1,14 @@
 mod engine;
 
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crossbeam::channel::Sender;
 use dioxus::prelude::*;
 
-use engine::{PlayerCommand, SharedState};
+use engine::{DeckCommand, DeckState, SharedState};
+use rustymixer_engine::{AtomicF32, Crossfader, PlaybackState};
 
 fn main() {
     tracing_subscriber::fmt::init();
@@ -14,180 +16,272 @@ fn main() {
     dioxus::launch(app);
 }
 
-/// Handle for sending commands to the engine and reading shared state.
-#[derive(Clone)]
-struct EngineHandle {
-    tx: Sender<PlayerCommand>,
+/// Persistent engine state shared via Dioxus signal.
+struct EngineCtx {
     shared: Arc<Mutex<SharedState>>,
+    crossfader: Arc<Crossfader>,
+    master_gain: Arc<AtomicF32>,
+    deck_tx: [Sender<DeckCommand>; 2],
 }
 
 fn app() -> Element {
-    // Initialise engine once (signal stores the handle, never mutated).
     let engine = use_signal(|| {
-        let (tx, rx) = crossbeam::channel::unbounded();
         let shared = Arc::new(Mutex::new(SharedState::default()));
-        engine::spawn_engine(rx, shared.clone());
-        EngineHandle { tx, shared }
+        let crossfader = Arc::new(Crossfader::default());
+        let master_gain = Arc::new(AtomicF32::new(0.8));
+
+        let deck_tx = engine::spawn_engine(
+            Arc::clone(&shared),
+            Arc::clone(&crossfader),
+            Arc::clone(&master_gain),
+        );
+
+        EngineCtx {
+            shared,
+            crossfader,
+            master_gain,
+            deck_tx,
+        }
     });
 
-    // Reactive UI state synced from the engine's SharedState.
-    let mut is_playing = use_signal(|| false);
-    let mut position_secs = use_signal(|| 0.0f64);
-    let mut duration_secs = use_signal(|| 0.0f64);
-    let mut volume = use_signal(|| 0.8f32);
-    let mut track_title = use_signal(|| String::new());
-    let mut track_artist = use_signal(|| String::new());
-    let mut loaded = use_signal(|| false);
+    let mut deck_a = use_signal(DeckState::default);
+    let mut deck_b = use_signal(DeckState::default);
+    let mut crossfader_pos = use_signal(|| 0.0f32);
+    let mut master_vol = use_signal(|| 0.8f32);
     let mut error_msg = use_signal(|| None::<String>);
 
-    // Sync engine state → UI signals at ~20 Hz.
+    // Sync engine state to UI at ~20 Hz.
     use_future(move || async move {
         loop {
             {
                 let eng = engine.read();
                 let s = eng.shared.lock().unwrap();
-                is_playing.set(s.is_playing);
-                position_secs.set(s.position_secs);
-                duration_secs.set(s.duration_secs);
-                volume.set(s.volume);
-                track_title.set(s.track_title.clone());
-                track_artist.set(s.track_artist.clone());
-                loaded.set(s.loaded);
+                deck_a.set(s.decks[0].clone());
+                deck_b.set(s.decks[1].clone());
+                crossfader_pos.set(s.crossfader);
+                master_vol.set(s.master_volume);
                 error_msg.set(s.error.clone());
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
     });
 
-    // Read current values for rendering.
-    let dur = *duration_secs.read();
-    let pos = *position_secs.read();
-    let vol = *volume.read();
-    let playing = *is_playing.read();
-    let has_track = *loaded.read();
-    let title = track_title.read().clone();
-    let artist = track_artist.read().clone();
     let err = error_msg.read().clone();
+    let xf = *crossfader_pos.read();
+    let mv = *master_vol.read();
+    let xf_slider = ((xf + 1.0) / 2.0 * 100.0) as i32;
+    let mv_pct = (mv * 100.0) as u32;
+
+    rsx! {
+        style { {CSS} }
+        div { class: "app",
+            div { class: "header",
+                h1 { "RustyMixer" }
+            }
+
+            if let Some(ref e) = err {
+                div { class: "error-banner", "{e}" }
+            }
+
+            div { class: "decks",
+                DeckPanel { deck_index: 0, state: deck_a, engine: engine, side: "a" }
+                DeckPanel { deck_index: 1, state: deck_b, engine: engine, side: "b" }
+            }
+
+            div { class: "master-section",
+                div { class: "crossfader-section",
+                    div { class: "crossfader-labels",
+                        span { "A" }
+                        span { class: "crossfader-title", "Crossfader" }
+                        span { "B" }
+                    }
+                    input {
+                        r#type: "range",
+                        class: "crossfader-slider",
+                        min: "0",
+                        max: "100",
+                        value: "{xf_slider}",
+                        oninput: move |evt: Event<FormData>| {
+                            if let Ok(v) = evt.value().parse::<f32>() {
+                                let pos = (v / 50.0) - 1.0;
+                                engine.read().crossfader.set_position(pos);
+                            }
+                        },
+                    }
+                }
+                div { class: "master-volume",
+                    span { class: "master-label", "Master: {mv_pct}%" }
+                    input {
+                        r#type: "range",
+                        class: "master-slider",
+                        min: "0",
+                        max: "100",
+                        value: "{mv_pct}",
+                        oninput: move |evt: Event<FormData>| {
+                            if let Ok(v) = evt.value().parse::<f32>() {
+                                engine.read().master_gain.store(v / 100.0, Ordering::Relaxed);
+                            }
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn DeckPanel(deck_index: usize, state: Signal<DeckState>, engine: Signal<EngineCtx>, side: String) -> Element {
+    let ds = state.read().clone();
+    let playing = ds.state == PlaybackState::Playing;
+    let has_track = ds.loaded;
 
     let track_display = if has_track {
-        if artist.is_empty() {
-            title.clone()
+        if ds.track_artist.is_empty() {
+            if ds.track_title.is_empty() {
+                "Unknown".to_string()
+            } else {
+                ds.track_title.clone()
+            }
         } else {
-            format!("{artist} \u{2014} {title}")
+            format!("{} \u{2014} {}", ds.track_artist, ds.track_title)
         }
     } else {
         "No track loaded".to_string()
     };
 
-    let pos_text = format!("{} / {}", format_time(pos), format_time(dur));
-    let progress_pct = if dur > 0.0 { pos / dur * 100.0 } else { 0.0 };
-    let vol_pct = (vol * 100.0) as u32;
+    let pos_text = format!("{} / {}", format_time(ds.position_secs), format_time(ds.duration_secs));
+    let progress_pct = if ds.duration_secs > 0.0 {
+        ds.position_secs / ds.duration_secs * 100.0
+    } else {
+        0.0
+    };
+    let vol_pct = (ds.volume * 100.0) as u32;
+    let rate_pct = ((ds.rate - 1.0) * 100.0) as i32;
+    let rate_display = if rate_pct >= 0 {
+        format!("+{rate_pct}%")
+    } else {
+        format!("{rate_pct}%")
+    };
+
+    let deck_class = format!("deck deck-{side}");
+    let deck_label = if side == "a" { "DECK A" } else { "DECK B" };
 
     rsx! {
-        style { {CSS} }
-        div { class: "app",
-            // Header
-            div { class: "header",
-                h1 { "RustyMixer" }
+        div { class: "{deck_class}",
+            div { class: "deck-header",
+                span { class: "deck-label", "{deck_label}" }
+                button {
+                    class: "btn btn-load",
+                    onclick: move |_| {
+                        let tx = engine.read().deck_tx[deck_index].clone();
+                        std::thread::spawn(move || {
+                            if let Some(path) = rfd::FileDialog::new()
+                                .add_filter("Audio", &["mp3", "flac", "wav", "ogg", "m4a", "aac", "aiff"])
+                                .pick_file()
+                            {
+                                let _ = tx.send(DeckCommand::LoadTrack(path));
+                            }
+                        });
+                    },
+                    "Load"
+                }
             }
 
-            div { class: "player",
-                // Track info
-                div { class: "track-info",
-                    span { class: "track-label", "Track: " }
-                    span { class: "track-name", "{track_display}" }
-                }
+            div { class: "track-info",
+                div { class: "track-name", "{track_display}" }
+            }
 
-                // Error banner
-                if let Some(ref e) = err {
-                    div { class: "error", "{e}" }
-                }
-
-                // Transport controls
-                div { class: "controls",
-                    button {
-                        class: "btn",
-                        disabled: !has_track || playing,
-                        onclick: move |_| {
-                            let _ = engine.read().tx.send(PlayerCommand::Play);
-                        },
-                        "\u{25B6} Play"
+            div { class: "position-section",
+                div { class: "position-text", "{pos_text}" }
+                div { class: "progress-container",
+                    div {
+                        class: "progress-fill",
+                        style: "width: {progress_pct:.1}%",
                     }
-                    button {
-                        class: "btn",
-                        disabled: !playing,
-                        onclick: move |_| {
-                            let _ = engine.read().tx.send(PlayerCommand::Pause);
-                        },
-                        "\u{23F8} Pause"
-                    }
-                    button {
-                        class: "btn",
-                        disabled: !has_track,
-                        onclick: move |_| {
-                            let _ = engine.read().tx.send(PlayerCommand::Stop);
-                        },
-                        "\u{23F9} Stop"
-                    }
-                    button {
-                        class: "btn btn-open",
-                        onclick: move |_| {
-                            let tx = engine.read().tx.clone();
-                            std::thread::spawn(move || {
-                                if let Some(path) = rfd::FileDialog::new()
-                                    .add_filter("Audio", &[
-                                        "mp3", "flac", "wav", "ogg", "m4a", "aac", "aiff",
-                                    ])
-                                    .pick_file()
-                                {
-                                    let _ = tx.send(PlayerCommand::Load(path));
-                                }
-                            });
-                        },
-                        "\u{1F4C1} Open"
-                    }
-                }
-
-                // Position + progress bar
-                div { class: "position-section",
-                    div { class: "position-text", "{pos_text}" }
-                    div { class: "progress-container",
-                        div {
-                            class: "progress-fill",
-                            style: "width: {progress_pct:.1}%",
-                        }
-                        input {
-                            r#type: "range",
-                            class: "progress-slider",
-                            min: "0",
-                            max: "{dur:.1}",
-                            step: "0.1",
-                            value: "{pos:.1}",
-                            disabled: !has_track,
-                            oninput: move |evt: Event<FormData>| {
-                                if let Ok(secs) = evt.value().parse::<f64>() {
-                                    let _ = engine.read().tx.send(PlayerCommand::Seek(secs));
-                                }
-                            },
-                        }
-                    }
-                }
-
-                // Volume slider
-                div { class: "volume-section",
-                    span { class: "volume-label", "Volume: {vol_pct}%" }
                     input {
                         r#type: "range",
-                        class: "volume-slider",
+                        class: "progress-slider",
                         min: "0",
-                        max: "100",
-                        value: "{vol_pct}",
+                        max: "{ds.duration_secs:.1}",
+                        step: "0.1",
+                        value: "{ds.position_secs:.1}",
+                        disabled: !has_track,
                         oninput: move |evt: Event<FormData>| {
-                            if let Ok(v) = evt.value().parse::<f32>() {
-                                let _ = engine.read().tx.send(PlayerCommand::SetVolume(v / 100.0));
+                            if let Ok(secs) = evt.value().parse::<f64>() {
+                                let sr = state.read().sample_rate;
+                                let frame = secs * sr as f64;
+                                let _ = engine.read().deck_tx[deck_index].send(DeckCommand::Seek(frame));
                             }
                         },
                     }
+                }
+            }
+
+            div { class: "controls",
+                button {
+                    class: if playing { "btn btn-transport active" } else { "btn btn-transport" },
+                    disabled: !has_track,
+                    onclick: move |_| {
+                        let eng = engine.read();
+                        if playing {
+                            let _ = eng.deck_tx[deck_index].send(DeckCommand::Pause);
+                        } else {
+                            let _ = eng.deck_tx[deck_index].send(DeckCommand::Play);
+                        }
+                    },
+                    if playing { "\u{23F8} Pause" } else { "\u{25B6} Play" }
+                }
+                button {
+                    class: "btn btn-transport",
+                    disabled: !has_track,
+                    onclick: move |_| {
+                        let _ = engine.read().deck_tx[deck_index].send(DeckCommand::Stop);
+                    },
+                    "\u{23F9} Stop"
+                }
+                button {
+                    class: "btn btn-transport btn-cue",
+                    disabled: !has_track,
+                    onclick: move |_| {
+                        let eng = engine.read();
+                        let _ = eng.deck_tx[deck_index].send(DeckCommand::Stop);
+                        let _ = eng.deck_tx[deck_index].send(DeckCommand::Seek(0.0));
+                    },
+                    "CUE"
+                }
+            }
+
+            div { class: "slider-section",
+                span { class: "slider-label", "Rate: {rate_display}" }
+                input {
+                    r#type: "range",
+                    class: "rate-slider",
+                    min: "-8",
+                    max: "8",
+                    step: "0.1",
+                    value: "{(ds.rate - 1.0) * 100.0:.1}",
+                    oninput: move |evt: Event<FormData>| {
+                        if let Ok(v) = evt.value().parse::<f32>() {
+                            let rate = 1.0 + v / 100.0;
+                            let _ = engine.read().deck_tx[deck_index].send(DeckCommand::SetRate(rate));
+                        }
+                    },
+                }
+            }
+
+            div { class: "slider-section",
+                span { class: "slider-label", "Vol: {vol_pct}%" }
+                input {
+                    r#type: "range",
+                    class: "volume-slider",
+                    min: "0",
+                    max: "100",
+                    value: "{vol_pct}",
+                    oninput: move |evt: Event<FormData>| {
+                        if let Ok(v) = evt.value().parse::<f32>() {
+                            let _ = engine.read().deck_tx[deck_index].send(DeckCommand::SetGain(v / 100.0));
+                        }
+                    },
                 }
             }
         }
@@ -207,73 +301,137 @@ fn format_time(secs: f64) -> String {
 const CSS: &str = r#"
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
-    background: #1a1a2e;
+    background: #121218;
     color: #e0e0e0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+    user-select: none;
 }
-.app { max-width: 560px; margin: 40px auto; padding: 0 16px; }
+.app {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 12px;
+}
 .header {
     text-align: center;
-    padding: 16px 0;
-    border-bottom: 1px solid #333;
-    margin-bottom: 24px;
+    padding: 10px 0;
+    margin-bottom: 12px;
 }
-.header h1 { font-size: 28px; color: #4a9eff; letter-spacing: 1px; }
-.player {
-    background: #16213e;
-    border-radius: 12px;
-    padding: 24px;
+.header h1 {
+    font-size: 22px;
+    color: #b0b0b0;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    font-weight: 300;
 }
-.track-info { margin-bottom: 16px; font-size: 16px; }
-.track-label { color: #888; }
-.track-name { color: #fff; font-weight: 600; }
-.error {
+.error-banner {
     background: #3a1a1a;
     color: #ff6b6b;
     padding: 8px 12px;
     border-radius: 6px;
     margin-bottom: 12px;
     font-size: 13px;
+    text-align: center;
 }
-.controls { display: flex; gap: 8px; margin-bottom: 20px; flex-wrap: wrap; }
-.btn {
-    padding: 8px 16px;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
+.decks {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+@media (max-width: 640px) {
+    .decks { grid-template-columns: 1fr; }
+}
+.deck {
+    background: #1a1a24;
+    border-radius: 8px;
+    padding: 16px;
+    border-top: 3px solid #333;
+}
+.deck-a { border-top-color: #4a9eff; }
+.deck-b { border-top-color: #ff6a4a; }
+.deck-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+.deck-label {
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    color: #888;
+}
+.deck-a .deck-label { color: #4a9eff; }
+.deck-b .deck-label { color: #ff6a4a; }
+.track-info { margin-bottom: 10px; min-height: 22px; }
+.track-name {
     font-size: 14px;
-    background: #2a3a5c;
-    color: #e0e0e0;
+    color: #ccc;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.btn {
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+    font-family: inherit;
+    background: #2a2a3a;
+    color: #ccc;
     transition: background 0.15s;
 }
-.btn:hover:not(:disabled) { background: #3a4f7a; }
-.btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn-open { background: #1a4a2e; }
-.btn-open:hover:not(:disabled) { background: #2a6a3e; }
-.position-section { margin-bottom: 20px; }
+.btn:hover:not(:disabled) { background: #3a3a4f; }
+.btn:disabled { opacity: 0.3; cursor: not-allowed; }
+.btn-load { background: #1a3a1a; color: #8f8; }
+.btn-load:hover:not(:disabled) { background: #2a5a2a; }
+.controls {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 12px;
+}
+.btn-transport {
+    flex: 1;
+    padding: 8px 4px;
+    font-size: 12px;
+}
+.btn-transport.active {
+    background: #1a3050;
+    color: #4a9eff;
+}
+.deck-b .btn-transport.active {
+    background: #3a1a10;
+    color: #ff6a4a;
+}
+.btn-cue { background: #3a3a1a; color: #ffcc4a; }
+.btn-cue:hover:not(:disabled) { background: #4a4a2a; }
+.position-section { margin-bottom: 12px; }
 .position-text {
     text-align: center;
-    font-size: 18px;
+    font-size: 16px;
     font-variant-numeric: tabular-nums;
-    margin-bottom: 8px;
-    color: #ccc;
+    margin-bottom: 4px;
+    color: #aaa;
 }
 .progress-container {
     position: relative;
-    height: 24px;
-    background: #0f1a2e;
-    border-radius: 4px;
+    height: 20px;
+    background: #0f0f1a;
+    border-radius: 3px;
     overflow: hidden;
 }
 .progress-fill {
     position: absolute;
     top: 0; left: 0;
     height: 100%;
-    background: #4a9eff;
-    opacity: 0.3;
-    transition: width 0.1s linear;
+    opacity: 0.25;
+    transition: width 0.08s linear;
     pointer-events: none;
 }
+.deck-a .progress-fill { background: #4a9eff; }
+.deck-b .progress-fill { background: #ff6a4a; }
 .progress-slider {
     position: absolute;
     top: 0; left: 0;
@@ -286,32 +444,111 @@ body {
 }
 .progress-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 14px; height: 24px;
-    background: #4a9eff;
+    width: 3px; height: 20px;
+    background: #fff;
     border: none;
-    border-radius: 2px;
     cursor: pointer;
 }
 .progress-slider::-webkit-slider-runnable-track {
-    height: 24px;
+    height: 20px;
     background: transparent;
 }
 .progress-slider:disabled { cursor: not-allowed; }
-.volume-section { display: flex; align-items: center; gap: 12px; }
-.volume-label { font-size: 14px; color: #888; min-width: 110px; }
-.volume-slider {
+.slider-section {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+.slider-label {
+    font-size: 12px;
+    color: #888;
+    min-width: 80px;
+    font-variant-numeric: tabular-nums;
+}
+.rate-slider, .volume-slider {
     flex: 1;
     -webkit-appearance: none;
     appearance: none;
+    height: 4px;
+    background: #0f0f1a;
+    border-radius: 2px;
+    cursor: pointer;
+}
+.rate-slider::-webkit-slider-thumb, .volume-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px; height: 14px;
+    background: #555;
+    border-radius: 50%;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.rate-slider::-webkit-slider-thumb:hover, .volume-slider::-webkit-slider-thumb:hover {
+    background: #888;
+}
+.deck-a .volume-slider::-webkit-slider-thumb { background: #4a9eff; }
+.deck-b .volume-slider::-webkit-slider-thumb { background: #ff6a4a; }
+.master-section {
+    background: #1a1a24;
+    border-radius: 8px;
+    padding: 16px;
+}
+.crossfader-section { margin-bottom: 12px; }
+.crossfader-labels {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 13px;
+    color: #888;
+    margin-bottom: 6px;
+    padding: 0 4px;
+}
+.crossfader-title {
+    font-size: 11px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: #555;
+}
+.crossfader-slider {
+    width: 100%;
+    -webkit-appearance: none;
+    appearance: none;
     height: 6px;
-    background: #0f1a2e;
+    background: linear-gradient(to right, #4a9eff, #333 45%, #333 55%, #ff6a4a);
     border-radius: 3px;
     cursor: pointer;
 }
-.volume-slider::-webkit-slider-thumb {
+.crossfader-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 16px; height: 16px;
-    background: #4a9eff;
+    width: 20px; height: 20px;
+    background: #ddd;
+    border-radius: 3px;
+    cursor: pointer;
+}
+.master-volume {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+.master-label {
+    font-size: 12px;
+    color: #888;
+    min-width: 100px;
+    font-variant-numeric: tabular-nums;
+}
+.master-slider {
+    flex: 1;
+    -webkit-appearance: none;
+    appearance: none;
+    height: 4px;
+    background: #0f0f1a;
+    border-radius: 2px;
+    cursor: pointer;
+}
+.master-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px; height: 14px;
+    background: #aaa;
     border-radius: 50%;
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- Replaces the single-deck player (issue #6) with a full two-deck DJ interface
- Two independent `DeckPanel` components (Deck A blue, Deck B orange) with load, play/pause, stop, CUE, seek, rate slider, and volume fader
- Horizontal crossfader widget blending between left/right-oriented decks via `Crossfader` from `rustymixer-engine`
- Master volume slider controlling overall output level
- Dark professional theme with responsive two-column CSS Grid layout
- Engine rewritten to use `EngineBuffer` per deck with manual mixing, crossfader gains, and master gain — all lock-free atomics

## Architecture
- UI sends `DeckCommand` variants via crossbeam channels (one per deck)
- Engine thread owns both `EngineBuffer`s and `EngineBufferHandle`s
- `SharedState` (mutex-protected) is polled at ~20 Hz by the UI for position/state updates
- Crossfader and master gain use `AtomicF32` / `Arc<Crossfader>` for lock-free UI-to-engine communication

## Test plan
- [x] `cargo build -p rustymixer-ui` compiles cleanly
- [x] `cargo clippy -p rustymixer-ui -- -D warnings` passes with zero warnings
- [x] `cargo test --workspace` — all 188 tests pass
- [ ] Manual: load different tracks on each deck, play independently
- [ ] Manual: crossfader blends audio between decks
- [ ] Manual: rate sliders change playback speed
- [ ] Manual: seeking via progress bar works on both decks
- [ ] Manual: master volume controls overall output

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)